### PR TITLE
Update repo in meta-netkan

### DIFF
--- a/CKAN/NearFutureProps.netkan
+++ b/CKAN/NearFutureProps.netkan
@@ -3,13 +3,13 @@
     "identifier":     "NearFutureProps",
     "name":           "Near Future IVA Props",
     "abstract":       "Prop pack used to accessorize and decorate IVA spaces",
-    "$kref":          "#/ckan/github/ChrisAdderley/NearFutureProps",
+    "$kref":          "#/ckan/github/post-kerbin-mining-corporation/NearFutureProps",
     "$vref":          "#/ckan/ksp-avc",
     "x_netkan_epoch": "1",
     "license":        "CC-BY-NC-SA-4.0",
     "resources": {
         "homepage": "https://forum.kerbalspaceprogram.com/index.php?/topic/166941-*",
-        "repository": "https://github.com/ChrisAdderley/NearFutureElectrical"
+        "repository": "https://github.com/post-kerbin-mining-corporation/NearFutureElectrical"
     },
     "supports": [
         { "name": "NearFutureSpacecraft"  },


### PR DESCRIPTION
GitHub likes to throw bogus API rate limiting errors when the CKAN bot crawls mods after their repositories change.
Now this is updated from ChrisAdderley to post-kerbin-mining-corporation.

Previously updated the link to the meta-netkans in KSP-CKAN/NetKAN#8264.

Tagging @ChrisAdderley because GitHub is shy about sending notifications for pull requests.